### PR TITLE
Update `{Arg,Opt}::parse_with()` and add `{Arg,Opt}::raw_value_or_empty()`

### DIFF
--- a/src/arg.rs
+++ b/src/arg.rs
@@ -207,6 +207,11 @@ impl Arg {
         }
     }
 
+    /// Returns the raw value of this argument, or an empty string if not present.
+    pub fn raw_value_or_empty(&self) -> &str {
+        self.raw_value().unwrap_or("")
+    }
+
     /// Returns the index at which the raw value of this argument was located in [`RawArgs`].
     pub fn index(&self) -> Option<usize> {
         if let Arg::Positional { index, .. } = self {

--- a/src/arg.rs
+++ b/src/arg.rs
@@ -158,10 +158,7 @@ impl Arg {
         let value = self.raw_value().ok_or_else(|| Error::MissingArg {
             arg: Box::new(self.clone()),
         })?;
-        value.parse::<T>().map_err(|e| Error::ParseArgError {
-            arg: Box::new(self.clone()),
-            reason: e.to_string(),
-        })
+        self.parse_with(|_| value.parse())
     }
 
     /// Parse the value of this argument if it is present.
@@ -174,11 +171,15 @@ impl Arg {
     }
 
     /// Similar to [`Arg::parse()`], but more flexible as this method allows you to specify an arbitrary parsing function.
-    pub fn parse_with<F, T>(&self, f: F) -> Result<T, Error>
+    pub fn parse_with<F, T, E>(&self, f: F) -> Result<T, Error>
     where
-        F: FnOnce(&Self) -> Result<T, Error>,
+        F: FnOnce(&Self) -> Result<T, E>,
+        E: std::fmt::Display,
     {
-        f(self)
+        f(self).map_err(|e| Error::ParseArgError {
+            arg: Box::new(self.clone()),
+            reason: e.to_string(),
+        })
     }
 
     /// Returns the specification of this argument.

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -344,6 +344,11 @@ impl Opt {
         }
     }
 
+    /// Returns the raw value of this option, or an empty string if not present.
+    pub fn raw_value_or_empty(&self) -> &str {
+        self.raw_value().unwrap_or("")
+    }
+
     /// Returns the index at which the raw value associated with the name of this option was located in [`RawArgs`].
     pub fn index(&self) -> Option<usize> {
         if let Opt::Long { index, .. } | Opt::Short { index, .. } = self {

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -290,10 +290,7 @@ impl Opt {
         let value = self.raw_value().ok_or_else(|| Error::MissingOpt {
             opt: Box::new(self.clone()),
         })?;
-        value.parse::<T>().map_err(|e| Error::ParseOptError {
-            opt: Box::new(self.clone()),
-            reason: e.to_string(),
-        })
+        self.parse_with(|_| value.parse())
     }
 
     /// Parse the value of this option if it is present.
@@ -306,11 +303,15 @@ impl Opt {
     }
 
     /// Similar to [`Opt::parse()`], but more flexible as this method allows you to specify an arbitrary parsing function.
-    pub fn parse_with<F, T>(&self, f: F) -> Result<T, Error>
+    pub fn parse_with<F, T, E>(&self, f: F) -> Result<T, Error>
     where
-        F: FnOnce(&Self) -> Result<T, Error>,
+        F: FnOnce(&Self) -> Result<T, E>,
+        E: std::fmt::Display,
     {
-        f(self)
+        f(self).map_err(|e| Error::ParseOptError {
+            opt: Box::new(self.clone()),
+            reason: e.to_string(),
+        })
     }
 
     /// Returns the specification of this option.


### PR DESCRIPTION
Copilot Summary
--------------------

This pull request includes changes to the `Arg` and `Opt` implementations in `src/arg.rs` and `src/opt.rs` to improve error handling and add new utility methods. The most important changes include modifying the `parse_with` method to handle custom error types and adding methods to return raw values or empty strings if not present.

Improvements to error handling:

* [`src/arg.rs`](diffhunk://#diff-a2f5019accd09bc830969d4890dc8eca8cdd9cfdfd27c350c4c317278b5c1a35L177-R182): Modified the `parse_with` method to handle custom error types by adding a new type parameter `E` and mapping errors to `Error::ParseArgError`.
* [`src/opt.rs`](diffhunk://#diff-b91b0157c73f1643f94c1e8e2d0a24eb8f05d017d943005c8671f6244d58ad17L309-R314): Modified the `parse_with` method to handle custom error types by adding a new type parameter `E` and mapping errors to `Error::ParseOptError`.

New utility methods:

* [`src/arg.rs`](diffhunk://#diff-a2f5019accd09bc830969d4890dc8eca8cdd9cfdfd27c350c4c317278b5c1a35R210-R214): Added `raw_value_or_empty` method to return the raw value of an argument or an empty string if not present.
* [`src/opt.rs`](diffhunk://#diff-b91b0157c73f1643f94c1e8e2d0a24eb8f05d017d943005c8671f6244d58ad17R347-R351): Added `raw_value_or_empty` method to return the raw value of an option or an empty string if not present.

Simplification of parse methods:

* [`src/arg.rs`](diffhunk://#diff-a2f5019accd09bc830969d4890dc8eca8cdd9cfdfd27c350c4c317278b5c1a35L161-R161): Simplified the `parse` method to use the `parse_with` method.
* [`src/opt.rs`](diffhunk://#diff-b91b0157c73f1643f94c1e8e2d0a24eb8f05d017d943005c8671f6244d58ad17L293-R293): Simplified the `parse` method to use the `parse_with` method.