### PR TITLE
Add summary help support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,7 @@ fn main() -> noargs::Result<()> {
         println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
         return Ok(());
     }
-    if noargs::HELP_FLAG.take(&mut args).is_present() {
-        args.metadata_mut().help_mode = true;
-    }
+    noargs::HELP_FLAG.take_help(&mut args);
 
     // Handle application specific args.
     let foo: usize = noargs::opt("foo").default("1").take(&mut args).parse()?;

--- a/src/args.rs
+++ b/src/args.rs
@@ -146,6 +146,9 @@ pub struct Metadata {
     /// - [`RawArgs::finish()`] will return `Ok(Some(help_text))` if successful
     /// - Only default and example values will be used when calling [`ArgSpec::take()`] or [`OptSpec::take()`]
     pub help_mode: bool,
+
+    /// If `true`, a full help text will be displayed.
+    pub detailed_help: bool,
 }
 
 impl Default for Metadata {
@@ -155,6 +158,7 @@ impl Default for Metadata {
             app_description: "",
             help_flag_name: Some("help"),
             help_mode: false,
+            detailed_help: false,
         }
     }
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -148,7 +148,7 @@ pub struct Metadata {
     pub help_mode: bool,
 
     /// If `true`, a full help text will be displayed.
-    pub detailed_help: bool,
+    pub full_help: bool,
 }
 
 impl Default for Metadata {
@@ -158,7 +158,7 @@ impl Default for Metadata {
             app_description: "",
             help_flag_name: Some("help"),
             help_mode: false,
-            detailed_help: false,
+            full_help: false,
         }
     }
 }

--- a/src/flag.rs
+++ b/src/flag.rs
@@ -119,8 +119,11 @@ impl FlagSpec {
     ///
     /// Specifically, the following code is executed:
     /// ```no_run
+    /// # use noargs::Flag;
+    /// # let mut args = noargs::raw_args();
+    /// # let flag = noargs::HELP_FLAG.take_help(&mut args);
     /// args.metadata_mut().help_mode = true;
-    /// args.metadata_mut().help_flag_name = Some(self.name);
+    /// args.metadata_mut().help_flag_name = Some(flag.spec().name);
     /// if matches!(flag, Flag::Long { .. }) {
     ///     args.metadata_mut().full_help = true;
     /// }

--- a/src/flag.rs
+++ b/src/flag.rs
@@ -114,6 +114,28 @@ impl FlagSpec {
             }
         })
     }
+
+    /// Similar to [`FlagSpec::take()`], but updates the help-related metadata of `args` when the flag is present.
+    ///
+    /// Specifically, the following code is executed:
+    /// ```no_run
+    /// args.metadata_mut().help_mode = true;
+    /// args.metadata_mut().help_flag_name = Some(self.name);
+    /// if matches!(flag, Flag::Long { .. }) {
+    ///     args.metadata_mut().full_help = true;
+    /// }
+    /// ```
+    pub fn take_help(self, args: &mut RawArgs) -> Flag {
+        let flag = self.take(args);
+        if flag.is_present() {
+            args.metadata_mut().help_mode = true;
+            args.metadata_mut().help_flag_name = Some(self.name);
+            if matches!(flag, Flag::Long { .. }) {
+                args.metadata_mut().full_help = true;
+            }
+        }
+        flag
+    }
 }
 
 impl Default for FlagSpec {

--- a/src/help.rs
+++ b/src/help.rs
@@ -306,9 +306,9 @@ Usage: <APP_NAME> [OPTIONS]
 
 Options:
   --help, -h:
-    Print help.
+    Print help ('-f' for summary)
   --version:
-    Print version.
+    Print version
 "#
         );
     }
@@ -337,7 +337,7 @@ Options:
 
 Options:
   --help, -h:
-    Print help.
+    Print help ('-f' for summary)
   --foo, -f <INTEGER>:
     An integer
     This is foo
@@ -373,7 +373,7 @@ Example:
 
 Options:
   --help, -h:
-    Print help.
+    Print help ('-f' for summary)
   --foo, -f <INTEGER>:
     An integer
 "#
@@ -428,7 +428,7 @@ Arguments:
 
 Options:
   --help, -h:
-    Print help.
+    Print help ('-f' for summary)
 "#
         );
     }
@@ -465,7 +465,7 @@ Commands:
 
 Options:
   --help, -h:
-    Print help.
+    Print help ('-f' for summary)
 "#
         );
     }
@@ -518,7 +518,7 @@ Arguments:
 
 Options:
   --help, -h:
-    Print help.
+    Print help ('-f' for summary)
 "#
         );
     }

--- a/src/help.rs
+++ b/src/help.rs
@@ -260,25 +260,23 @@ impl<'a> HelpBuilder<'a> {
         match entry {
             Taken::Opt(opt) => {
                 let opt = opt.spec();
-                if let Some(short) = opt.short {
-                    self.fmt
-                        .bold(&format!("--{}, -{short} <{}>", opt.name, opt.ty))
-                        .into_owned()
-                } else {
-                    self.fmt
-                        .bold(&format!("--{} <{}>", opt.name, opt.ty))
-                        .into_owned()
-                }
+                let name = match (opt.short, self.is_full_mode()) {
+                    (Some(short), false) => format!("-{short}, --{} <{}>", opt.name, opt.ty),
+                    (Some(short), true) => format!("--{}, -{short} <{}>", opt.name, opt.ty),
+                    (None, false) => format!("    --{} <{}>", opt.name, opt.ty),
+                    (None, true) => format!("--{} <{}>", opt.name, opt.ty),
+                };
+                self.fmt.bold(&name).into_owned()
             }
             Taken::Flag(flag) => {
                 let flag = flag.spec();
-                if let Some(short) = flag.short {
-                    self.fmt
-                        .bold(&format!("--{}, -{short}", flag.name))
-                        .into_owned()
-                } else {
-                    self.fmt.bold(&format!("--{}", flag.name)).into_owned()
-                }
+                let name = match (flag.short, self.is_full_mode()) {
+                    (Some(short), false) => format!("-{short}, --{}", flag.name),
+                    (Some(short), true) => format!("--{}, -{short}", flag.name),
+                    (None, false) => format!("    --{}", flag.name),
+                    (None, true) => format!("--{}", flag.name),
+                };
+                self.fmt.bold(&name).into_owned()
             }
             Taken::Arg(arg) => {
                 if arg.spec().example.is_some() {
@@ -396,8 +394,8 @@ mod tests {
 Usage: <APP_NAME> [OPTIONS]
 
 Options:
-  --help, -h Print help ('--help' for full help, '-h' for summary)
-  --version  Print version
+  -h, --help    Print help ('--help' for full help, '-h' for summary)
+      --version Print version
 "#
         );
     }
@@ -425,8 +423,8 @@ Options:
             r#"Usage: <APP_NAME> [OPTIONS]
 
 Options:
-  --help, -h          Print help ('--help' for full help, '-h' for summary)
-  --foo, -f <INTEGER> An integer [env: FOO_ENV] [default: 10]
+  -h, --help          Print help ('--help' for full help, '-h' for summary)
+  -f, --foo <INTEGER> An integer [env: FOO_ENV] [default: 10]
 "#
         );
 
@@ -475,8 +473,8 @@ Example:
   $ <APP_NAME> --foo 10
 
 Options:
-  --help, -h          Print help ('--help' for full help, '-h' for summary)
-  --foo, -f <INTEGER> An integer
+  -h, --help          Print help ('--help' for full help, '-h' for summary)
+  -f, --foo <INTEGER> An integer
 "#
         );
     }
@@ -524,7 +522,7 @@ Arguments:
   [MULTI]    Baz
 
 Options:
-  --help, -h Print help ('--help' for full help, '-h' for summary)
+  -h, --help Print help ('--help' for full help, '-h' for summary)
 "#
         );
 
@@ -586,7 +584,7 @@ Commands:
   get Get an entry
 
 Options:
-  --help, -h Print help ('--help' for full help, '-h' for summary)
+  -h, --help Print help ('--help' for full help, '-h' for summary)
 "#
         );
 
@@ -657,7 +655,7 @@ Arguments:
   <KEY> A key string
 
 Options:
-  --help, -h Print help ('--help' for full help, '-h' for summary)
+  -h, --help Print help ('--help' for full help, '-h' for summary)
 "#
         );
 

--- a/src/help.rs
+++ b/src/help.rs
@@ -172,7 +172,7 @@ impl<'a> HelpBuilder<'a> {
         (
             self.log
                 .iter()
-                .filter(|e| f(*e))
+                .filter(|e| f(e))
                 .map(|e| self.entry_name(e).len())
                 .max()
                 .unwrap_or_default(),

--- a/src/help.rs
+++ b/src/help.rs
@@ -58,7 +58,12 @@ impl<'a> HelpBuilder<'a> {
         self.build_commands();
         self.build_arguments();
         self.build_options();
-        self.fmt.finish()
+
+        let mut text = self.fmt.finish();
+        if text.ends_with("\n\n") {
+            text.pop();
+        }
+        text
     }
 
     fn build_description(&mut self) {
@@ -158,13 +163,12 @@ impl<'a> HelpBuilder<'a> {
             };
             let cmd = cmd.spec();
 
-            self.fmt.write(&format!("  {}:\n", self.fmt.bold(cmd.name)));
+            self.fmt.write(&format!("  {}\n", self.fmt.bold(cmd.name)));
             for line in cmd.doc.lines() {
                 self.fmt.write(&format!("    {line}\n"));
             }
+            self.fmt.write("\n");
         }
-
-        self.fmt.write("\n");
     }
 
     fn build_arguments(&mut self) {
@@ -188,10 +192,10 @@ impl<'a> HelpBuilder<'a> {
 
             if arg.example.is_some() {
                 self.fmt
-                    .write(&format!("  <{}>:\n", self.fmt.bold(arg.name)));
+                    .write(&format!("  <{}>\n", self.fmt.bold(arg.name)));
             } else {
                 self.fmt
-                    .write(&format!("  [{}]:\n", self.fmt.bold(arg.name)));
+                    .write(&format!("  [{}]\n", self.fmt.bold(arg.name)));
             }
 
             for line in arg.doc.lines() {
@@ -200,9 +204,9 @@ impl<'a> HelpBuilder<'a> {
             if let Some(default) = arg.default {
                 self.fmt.write(&format!("    [default: {default}]\n"));
             }
-        }
 
-        self.fmt.write("\n");
+            self.fmt.write("\n");
+        }
     }
 
     fn build_options(&mut self) {
@@ -238,7 +242,7 @@ impl<'a> HelpBuilder<'a> {
                 format!("--{name}")
             };
             self.fmt.write(&format!(
-                "  {}{}:\n",
+                "  {}{}\n",
                 self.fmt.bold(&names),
                 if let Some(ty) = ty {
                     Cow::Owned(format!(" <{ty}>"))
@@ -255,6 +259,8 @@ impl<'a> HelpBuilder<'a> {
             if let Some(default) = default {
                 self.fmt.write(&format!("    [default: {default}]\n"));
             }
+
+            self.fmt.write("\n");
         }
     }
 
@@ -305,9 +311,10 @@ mod tests {
 Usage: <APP_NAME> [OPTIONS]
 
 Options:
-  --help, -h:
+  --help, -h
     Print help ('-f' for summary)
-  --version:
+
+  --version
     Print version
 "#
         );
@@ -336,9 +343,10 @@ Options:
             r#"Usage: <APP_NAME> [OPTIONS]
 
 Options:
-  --help, -h:
+  --help, -h
     Print help ('-f' for summary)
-  --foo, -f <INTEGER>:
+
+  --foo, -f <INTEGER>
     An integer
     This is foo
     [env: FOO_ENV]
@@ -372,9 +380,10 @@ Example:
   $ <APP_NAME> --foo 10
 
 Options:
-  --help, -h:
+  --help, -h
     Print help ('-f' for summary)
-  --foo, -f <INTEGER>:
+
+  --foo, -f <INTEGER>
     An integer
 "#
         );
@@ -418,16 +427,18 @@ Example:
   $ <APP_NAME> 3
 
 Arguments:
-  <REQUIRED>:
+  <REQUIRED>
     Foo
-  [OPTIONAL]:
+
+  [OPTIONAL]
     Bar
     [default: 9]
-  [MULTI]:
+
+  [MULTI]
     Baz
 
 Options:
-  --help, -h:
+  --help, -h
     Print help ('-f' for summary)
 "#
         );
@@ -458,13 +469,14 @@ Options:
             r#"Usage: <APP_NAME> [OPTIONS] <COMMAND>
 
 Commands:
-  put:
+  put
     Put an entry
-  get:
+
+  get
     Get an entry
 
 Options:
-  --help, -h:
+  --help, -h
     Print help ('-f' for summary)
 "#
         );
@@ -513,11 +525,11 @@ Example:
   $ <APP_NAME> get hi
 
 Arguments:
-  <KEY>:
+  <KEY>
     A key string
 
 Options:
-  --help, -h:
+  --help, -h
     Print help ('-f' for summary)
 "#
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,9 @@ pub const fn cmd(name: &'static str) -> CmdSpec {
 }
 
 /// Well-known flag (`--help, -h`) for printing help information.
-pub const HELP_FLAG: FlagSpec = flag("help").short('h').doc("Print help ('-f' for summary)");
+pub const HELP_FLAG: FlagSpec = flag("help")
+    .short('h')
+    .doc("Print help ('--help' for full help, '-h' for summary)");
 
 /// Well-known flag (`--version`) for printing version information.
 pub const VERSION_FLAG: FlagSpec = flag("version").doc("Print version");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,9 +27,7 @@
 //!         println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
 //!         return Ok(());
 //!     }
-//!     if noargs::HELP_FLAG.take(&mut args).is_present() {
-//!         args.metadata_mut().help_mode = true;
-//!     }
+//!     noargs::HELP_FLAG.take_help(&mut args);
 //!
 //!     // Handle application specific args.
 //!     let foo: usize = noargs::opt("foo").default("1").take(&mut args).parse()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,10 +95,10 @@ pub const fn cmd(name: &'static str) -> CmdSpec {
 }
 
 /// Well-known flag (`--help, -h`) for printing help information.
-pub const HELP_FLAG: FlagSpec = flag("help").short('h').doc("Print help.");
+pub const HELP_FLAG: FlagSpec = flag("help").short('h').doc("Print help ('-f' for summary)");
 
 /// Well-known flag (`--version`) for printing version information.
-pub const VERSION_FLAG: FlagSpec = flag("version").doc("Print version.");
+pub const VERSION_FLAG: FlagSpec = flag("version").doc("Print version");
 
 /// Well-known flag (`--`) to indicate the end of options (named arguments).
 pub const OPTIONS_END_FLAG: FlagSpec =


### PR DESCRIPTION
Copilot Summary
------------------

This pull request includes changes to improve the handling and display of help messages in the `noargs` library. The most important changes include the addition of a `full_help` flag, modifications to the `HelpBuilder` to support different levels of help detail, and updates to the `HELP_FLAG` to differentiate between summary and full help.

Enhancements to help message handling:

* [`src/args.rs`](diffhunk://#diff-c3fd08257cd326dfa1c2a3c0a69e6b842f194950ac32e7b2c6e2750f52d1765fR149-R151): Added `full_help` field to `Metadata` struct and updated its default implementation to include this new field. [[1]](diffhunk://#diff-c3fd08257cd326dfa1c2a3c0a69e6b842f194950ac32e7b2c6e2750f52d1765fR149-R151) [[2]](diffhunk://#diff-c3fd08257cd326dfa1c2a3c0a69e6b842f194950ac32e7b2c6e2750f52d1765fR161)
* [`src/flag.rs`](diffhunk://#diff-cf56a442b181f245ec9700f63ad02e773b3399a050218b47d9fb4050fd0bedc2R117-R141): Introduced `take_help` method in `FlagSpec` to update help-related metadata when the help flag is present.
* [`src/help.rs`](diffhunk://#diff-efff32f1ad66f01a7a8493832cadde5e3ab0d4bf9c0c911720c4859a82324e35R54-R86): Enhanced `HelpBuilder` to support full and summary help modes, including new methods `is_full_mode`, `doc_lines`, and `calc_width_offset_newline`. Updated various sections to use these methods for conditional help text display. [[1]](diffhunk://#diff-efff32f1ad66f01a7a8493832cadde5e3ab0d4bf9c0c911720c4859a82324e35R54-R86) [[2]](diffhunk://#diff-efff32f1ad66f01a7a8493832cadde5e3ab0d4bf9c0c911720c4859a82324e35R165-R213) [[3]](diffhunk://#diff-efff32f1ad66f01a7a8493832cadde5e3ab0d4bf9c0c911720c4859a82324e35R222-R223) [[4]](diffhunk://#diff-efff32f1ad66f01a7a8493832cadde5e3ab0d4bf9c0c911720c4859a82324e35L189-R289) [[5]](diffhunk://#diff-efff32f1ad66f01a7a8493832cadde5e3ab0d4bf9c0c911720c4859a82324e35R299-R311) [[6]](diffhunk://#diff-efff32f1ad66f01a7a8493832cadde5e3ab0d4bf9c0c911720c4859a82324e35L235-R346) [[7]](diffhunk://#diff-efff32f1ad66f01a7a8493832cadde5e3ab0d4bf9c0c911720c4859a82324e35L308-R398) [[8]](diffhunk://#diff-efff32f1ad66f01a7a8493832cadde5e3ab0d4bf9c0c911720c4859a82324e35L339-R442) [[9]](diffhunk://#diff-efff32f1ad66f01a7a8493832cadde5e3ab0d4bf9c0c911720c4859a82324e35L375-R477) [[10]](diffhunk://#diff-efff32f1ad66f01a7a8493832cadde5e3ab0d4bf9c0c911720c4859a82324e35L390-R489) [[11]](diffhunk://#diff-efff32f1ad66f01a7a8493832cadde5e3ab0d4bf9c0c911720c4859a82324e35L421-R553) [[12]](diffhunk://#diff-efff32f1ad66f01a7a8493832cadde5e3ab0d4bf9c0c911720c4859a82324e35L461-R607) [[13]](diffhunk://#diff-efff32f1ad66f01a7a8493832cadde5e3ab0d4bf9c0c911720c4859a82324e35L516-R678)

Updates to flag documentation:

* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L98-R101): Updated `HELP_FLAG` to include a more descriptive message differentiating between summary and full help.

Minor code cleanup:

* [`src/help.rs`](diffhunk://#diff-efff32f1ad66f01a7a8493832cadde5e3ab0d4bf9c0c911720c4859a82324e35L1-R1): Removed unnecessary import of `std::borrow::Cow`.