### PR TITLE
Quote example command-line args in help text if need

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -183,13 +183,23 @@ impl Taken {
 
     pub fn example(&self) -> Option<Cow<'static, str>> {
         match self {
-            Taken::Arg(arg) => arg.spec().example.map(Cow::Borrowed),
+            Taken::Arg(arg) => arg.spec().example.map(Self::quote_if_need),
             Taken::Opt(opt) => opt
                 .spec()
                 .example
-                .map(|v| Cow::Owned(format!("--{} {v}", opt.spec().name))),
+                .map(|v| Cow::Owned(format!("--{} {}", opt.spec().name, Self::quote_if_need(v)))),
             Taken::Cmd(cmd) if cmd.is_present() => Some(Cow::Borrowed(cmd.spec().name)),
             _ => None,
+        }
+    }
+
+    fn quote_if_need(s: &'static str) -> Cow<'static, str> {
+        if s.contains('"') && !s.contains('\'') {
+            Cow::Owned(format!("'{}'", s))
+        } else if s.contains([' ', '\'']) {
+            Cow::Owned(format!("{:?}", s))
+        } else {
+            Cow::Borrowed(s)
         }
     }
 

--- a/src/help.rs
+++ b/src/help.rs
@@ -156,7 +156,14 @@ impl<'a> HelpBuilder<'a> {
         // [NOTE] Need to use `self.args.log()` instead of `self.log` here.
         for entry in self.args.log() {
             if let Some(example) = entry.example() {
-                self.fmt.write(&format!(" {example}"));
+                let example = if example.contains('"') && !example.contains('\'') {
+                    format!("'{}'", example)
+                } else if example.contains([' ', '\'']) {
+                    format!("{:?}", example)
+                } else {
+                    example.into_owned()
+                };
+                self.fmt.write(&format!(" {}", example));
             }
         }
         self.fmt.write("\n\n");

--- a/src/help.rs
+++ b/src/help.rs
@@ -156,16 +156,10 @@ impl<'a> HelpBuilder<'a> {
         // [NOTE] Need to use `self.args.log()` instead of `self.log` here.
         for entry in self.args.log() {
             if let Some(example) = entry.example() {
-                let example = if example.contains('"') && !example.contains('\'') {
-                    format!("'{}'", example)
-                } else if example.contains([' ', '\'']) {
-                    format!("{:?}", example)
-                } else {
-                    example.into_owned()
-                };
                 self.fmt.write(&format!(" {}", example));
             }
         }
+
         self.fmt.write("\n\n");
     }
 


### PR DESCRIPTION
# Copilot Summary 

This pull request includes changes to enhance the handling of example strings and improve the formatting in the help builder. The most important changes include adding a new method to handle quoting of example strings and updating the formatting in the help builder.

Enhancements to example string handling:

* [`src/args.rs`](diffhunk://#diff-c3fd08257cd326dfa1c2a3c0a69e6b842f194950ac32e7b2c6e2750f52d1765fL186-R205): Added a new method `quote_if_need` in the `Taken` implementation to handle quoting of example strings based on their content. Updated the `example` method to use this new method.

Formatting improvements:

* [`src/help.rs`](diffhunk://#diff-efff32f1ad66f01a7a8493832cadde5e3ab0d4bf9c0c911720c4859a82324e35L159-R162): Modified the `HelpBuilder` implementation to ensure a space is added before example strings in the formatted output.