### PR TITLE
Rename `raw_value_or_empty()` to `value()` and deprecate `raw_value()` in favor of `value()`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -106,7 +106,7 @@ impl Error {
                 fmt.write(&format!(
                     "argument '{}' has an invalid value {:?}: {reason}",
                     fmt.bold(arg.spec().name),
-                    arg.raw_value().unwrap_or_default()
+                    arg.value()
                 ));
                 if let Some(metadata) = arg.metadata() {
                     metadata
@@ -143,7 +143,7 @@ impl Error {
                 };
                 fmt.write(&format!(
                     "{name} has an invalid value {:?}: {reason}",
-                    opt.raw_value().unwrap_or_default()
+                    opt.value()
                 ));
                 if let Some(metadata) = opt.metadata() {
                     metadata

--- a/src/error.rs
+++ b/src/error.rs
@@ -152,14 +152,26 @@ impl Error {
                 }
             }
             Error::MissingOpt { opt } => {
-                let name = match &**opt {
-                    Opt::Short {
-                        spec: OptSpec { short: Some(c), .. },
-                        ..
-                    } => fmt.bold(&format!("-{c}")).into_owned(),
-                    _ => fmt.bold(&format!("--{}", opt.spec().name)).into_owned(),
+                match **opt {
+                    Opt::MissingValue {
+                        spec:
+                            OptSpec {
+                                short: Some(name), ..
+                            },
+                        long: false,
+                    } => {
+                        let name = fmt.bold(&format!("-{name}")).into_owned();
+                        fmt.write(&format!("missing '{name}' value"));
+                    }
+                    Opt::MissingValue { spec, .. } => {
+                        let name = fmt.bold(&format!("--{}", spec.name)).into_owned();
+                        fmt.write(&format!("missing '{name}' value"));
+                    }
+                    _ => {
+                        let name = fmt.bold(&format!("--{}", opt.spec().name)).into_owned();
+                        fmt.write(&format!("missing '{name}' option"));
+                    }
                 };
-                fmt.write(&format!("missing '{name}' value"));
                 if let Some(metadata) = opt.metadata() {
                     metadata
                 } else {


### PR DESCRIPTION
# Copilot Summary

This pull request introduces several changes to the `Arg` and `Opt` handling in the `src/arg.rs` and `src/opt.rs` files, respectively. The primary goal is to replace the usage of `raw_value` with `value` and deprecate the `raw_value` methods in favor of `value` and `is_present` methods.

### Changes to `Arg` handling:

* Replaced `raw_value` with `value` in `ArgSpec` and `Arg` enums. (`src/arg.rs` - [[1]](diffhunk://#diff-a2f5019accd09bc830969d4890dc8eca8cdd9cfdfd27c350c4c317278b5c1a35L105-R105) [[2]](diffhunk://#diff-a2f5019accd09bc830969d4890dc8eca8cdd9cfdfd27c350c4c317278b5c1a35L136-R136)
* Modified the `parse` method in `Arg` to use `is_present` and `value` instead of `raw_value`. (`src/arg.rs` - [src/arg.rsL158-R161](diffhunk://#diff-a2f5019accd09bc830969d4890dc8eca8cdd9cfdfd27c350c4c317278b5c1a35L158-R161))
* Deprecated `raw_value` and `raw_value_or_empty` methods, recommending the use of `value` and `is_present` methods instead. (`src/arg.rs` - [src/arg.rsR204-R222](diffhunk://#diff-a2f5019accd09bc830969d4890dc8eca8cdd9cfdfd27c350c4c317278b5c1a35R204-R222))

### Changes to `Opt` handling:

* Replaced `raw_value` with `value` in `OptSpec` and `Opt` enums. (`src/opt.rs` - [[1]](diffhunk://#diff-b91b0157c73f1643f94c1e8e2d0a24eb8f05d017d943005c8671f6244d58ad17L138-L143) [[2]](diffhunk://#diff-b91b0157c73f1643f94c1e8e2d0a24eb8f05d017d943005c8671f6244d58ad17L168-R165) [[3]](diffhunk://#diff-b91b0157c73f1643f94c1e8e2d0a24eb8f05d017d943005c8671f6244d58ad17L178-R175) [[4]](diffhunk://#diff-b91b0157c73f1643f94c1e8e2d0a24eb8f05d017d943005c8671f6244d58ad17L196-R193) [[5]](diffhunk://#diff-b91b0157c73f1643f94c1e8e2d0a24eb8f05d017d943005c8671f6244d58ad17L207-R204) [[6]](diffhunk://#diff-b91b0157c73f1643f94c1e8e2d0a24eb8f05d017d943005c8671f6244d58ad17L224-R221) [[7]](diffhunk://#diff-b91b0157c73f1643f94c1e8e2d0a24eb8f05d017d943005c8671f6244d58ad17L257-R265)
* Modified the `parse` method in `Opt` to use `is_present` and `value` instead of `raw_value`. (`src/opt.rs` - [src/opt.rsL290-R290](diffhunk://#diff-b91b0157c73f1643f94c1e8e2d0a24eb8f05d017d943005c8671f6244d58ad17L290-R290))
* Deprecated `raw_value` and `raw_value_or_empty` methods, recommending the use of `value` and `is_present` methods instead. (`src/opt.rs` - [src/opt.rsR335-R354](diffhunk://#diff-b91b0157c73f1643f94c1e8e2d0a24eb8f05d017d943005c8671f6244d58ad17R335-R354))

### Changes to `Error` handling:

* Updated error formatting to use `value` instead of `raw_value`. (`src/error.rs` - [[1]](diffhunk://#diff-97e25e2a0e41c578875856e97b659be2719a65227c104b992e3144efa000c35eL109-R109) [[2]](diffhunk://#diff-97e25e2a0e41c578875856e97b659be2719a65227c104b992e3144efa000c35eL146-R146)