### PR TITLE
Change positional argument name handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ fn main() -> noargs::Result<()> {
     // Handle application specific args.
     let foo: usize = noargs::opt("foo").default("1").take(&mut args).parse()?;
     let bar: bool = noargs::flag("bar").take(&mut args).is_present();
-    let baz: Option<String> = noargs::arg("baz").take(&mut args).parse_if_present()?;
+    let baz: Option<String> = noargs::arg("[BAZ]").take(&mut args).parse_if_present()?;
 
     // Check unexpected args and build help text if need.
     if let Some(help) = args.finish()? {

--- a/src/arg.rs
+++ b/src/arg.rs
@@ -30,7 +30,7 @@ pub struct ArgSpec {
 impl ArgSpec {
     /// The default specification.
     pub const DEFAULT: Self = Self {
-        name: "ARGUMENT",
+        name: "<ARGUMENT>",
         doc: "",
         default: None,
         example: None,

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -38,10 +38,6 @@ impl Formatter {
         }
     }
 
-    pub fn text(&self) -> &str {
-        &self.text
-    }
-
     pub fn finish(self) -> String {
         self.text
     }

--- a/src/help.rs
+++ b/src/help.rs
@@ -122,16 +122,8 @@ impl<'a> HelpBuilder<'a> {
             };
             let arg = arg.spec();
 
-            if last == Some(arg) {
-                if !self.fmt.text().ends_with("...") {
-                    self.fmt.write("...");
-                }
-            } else if arg.example.is_some() {
-                // Required argument.
-                self.fmt.write(&format!(" <{}>", arg.name));
-            } else {
-                // Optional argument.
-                self.fmt.write(&format!(" [{}]", arg.name));
+            if last != Some(arg) {
+                self.fmt.write(&format!(" {}", arg.name));
             }
             last = Some(arg);
         }
@@ -280,11 +272,7 @@ impl<'a> HelpBuilder<'a> {
                 self.fmt.bold(&name).into_owned()
             }
             Taken::Arg(arg) => {
-                if arg.spec().example.is_some() {
-                    format!("<{}>", self.fmt.bold(arg.spec().name))
-                } else {
-                    format!("[{}]", self.fmt.bold(arg.spec().name))
-                }
+                format!("{}", self.fmt.bold(arg.spec().name))
             }
             Taken::Cmd(cmd) => self.fmt.bold(cmd.spec().name).into_owned(),
         }
@@ -486,14 +474,14 @@ Options:
         args.metadata_mut().app_description = "";
         HELP_FLAG.take(&mut args);
         ArgSpec {
-            name: "REQUIRED",
+            name: "<REQUIRED>",
             doc: "Foo\nDetail is foo",
             example: Some("3"),
             ..Default::default()
         }
         .take(&mut args);
         ArgSpec {
-            name: "OPTIONAL",
+            name: "[OPTIONAL]",
             doc: "Bar",
             default: Some("9"),
             ..Default::default()
@@ -501,7 +489,7 @@ Options:
         .take(&mut args);
         for _ in 0..3 {
             ArgSpec {
-                name: "MULTI",
+                name: "[MULTI]...",
                 doc: "Baz",
                 ..Default::default()
             }
@@ -520,7 +508,7 @@ Example:
 Arguments:
   <REQUIRED> Foo
   [OPTIONAL] Bar [default: 9]
-  [MULTI]    Baz
+  [MULTI]... Baz
 
 Options:
   -h, --help Print help ('--help' for full help, '-h' for summary)
@@ -546,7 +534,7 @@ Arguments:
     Bar
     [default: 9]
 
-  [MULTI]
+  [MULTI]...
     Baz
 
 Options:
@@ -635,7 +623,7 @@ Options:
         }
         .take(&mut args);
         ArgSpec {
-            name: "KEY",
+            name: "<KEY>",
             doc: "A key string",
             example: Some("hi"),
             min_index: cmd.index(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ pub fn raw_args() -> RawArgs {
 ///
 /// # Recommended Naming Convention
 ///
-/// - Requierd: `<NAME>`
+/// - Required: `<NAME>`
 /// - Optional: `[NAME]`
 /// - Zero or more: `[NAME]...`
 /// - One or more: `<NAME>...`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,13 @@ pub fn raw_args() -> RawArgs {
 }
 
 /// Makes an [`ArgSpec`] instance with a specified name.
+///
+/// # Recommended Naming Convention
+///
+/// - Requierd: `<NAME>`
+/// - Optional: `[NAME]`
+/// - Zero or more: `[NAME]...`
+/// - One or more: `<NAME>...`
 pub const fn arg(name: &'static str) -> ArgSpec {
     ArgSpec::new(name)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 //!     // Handle application specific args.
 //!     let foo: usize = noargs::opt("foo").default("1").take(&mut args).parse()?;
 //!     let bar: bool = noargs::flag("bar").take(&mut args).is_present();
-//!     let baz: Option<String> = noargs::arg("baz").take(&mut args).parse_if_present()?;
+//!     let baz: Option<String> = noargs::arg("[BAZ]").take(&mut args).parse_if_present()?;
 //!
 //!     // Check unexpected args and build help text if need.
 //!     if let Some(help) = args.finish()? {


### PR DESCRIPTION
# Copilot Summary 

This pull request includes changes to improve the readability and consistency of argument specifications and help text formatting in the codebase. The most important changes include updating argument naming conventions, simplifying the `HelpBuilder` implementation, and removing redundant methods.

### Improvements to argument naming conventions:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L50-R50): Changed the argument name from `baz` to `[BAZ]` to follow the new naming convention.
* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L35-R35): Updated the example argument name from `baz` to `[BAZ]` in the documentation.
* [`src/arg.rs`](diffhunk://#diff-a2f5019accd09bc830969d4890dc8eca8cdd9cfdfd27c350c4c317278b5c1a35L33-R33): Modified the default argument name from `"ARGUMENT"` to `"<ARGUMENT>"`.
* [`src/help.rs`](diffhunk://#diff-efff32f1ad66f01a7a8493832cadde5e3ab0d4bf9c0c911720c4859a82324e35L489-R492): Updated multiple argument names to follow the new naming conventions (`<REQUIRED>`, `[OPTIONAL]`, `[MULTI]...`, `<KEY>`). [[1]](diffhunk://#diff-efff32f1ad66f01a7a8493832cadde5e3ab0d4bf9c0c911720c4859a82324e35L489-R492) [[2]](diffhunk://#diff-efff32f1ad66f01a7a8493832cadde5e3ab0d4bf9c0c911720c4859a82324e35L638-R626)

### Simplification of `HelpBuilder` implementation:

* [`src/help.rs`](diffhunk://#diff-efff32f1ad66f01a7a8493832cadde5e3ab0d4bf9c0c911720c4859a82324e35L125-R126): Simplified the logic for appending argument names in the `HelpBuilder` implementation by removing conditional checks and redundant code. [[1]](diffhunk://#diff-efff32f1ad66f01a7a8493832cadde5e3ab0d4bf9c0c911720c4859a82324e35L125-R126) [[2]](diffhunk://#diff-efff32f1ad66f01a7a8493832cadde5e3ab0d4bf9c0c911720c4859a82324e35L283-R275)

### Removal of redundant methods:

* [`src/formatter.rs`](diffhunk://#diff-cffebbb289ff3011edae459ca9e6843092b4b3c45a757f4964b8f633ca669c1eL41-L44): Removed the unused `text` method from the `Formatter` implementation.

### Documentation updates:

* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R76-R82): Added a recommended naming convention section to the `arg` function documentation.