### PR TITLE
Add `{Arg,Opt,Flag,Cmd}::present()` and deprecate `Cmd::ok()`

### DIFF
--- a/src/arg.rs
+++ b/src/arg.rs
@@ -200,6 +200,11 @@ impl Arg {
         !matches!(self, Self::None { .. })
     }
 
+    /// Returns `Some(self)` if this argument is present.
+    pub fn present(self) -> Option<Self> {
+        self.is_present().then_some(self)
+    }
+
     /// Returns the raw value of this argument.
     #[deprecated(since = "0.3.0", note = "please use `present()` and `value()` instead")]
     pub fn raw_value(&self) -> Option<&str> {

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -127,9 +127,9 @@ mod tests {
     #[test]
     fn cmd_and_flag() {
         let mut args = args(&["test", "--foo", "run", "--foo"]);
-        if let Some(_cmd) = cmd("bar").take(&mut args).ok() {
+        if let Some(_cmd) = cmd("bar").take(&mut args).present() {
             panic!();
-        } else if let Some(cmd) = cmd("run").take(&mut args).ok() {
+        } else if let Some(cmd) = cmd("run").take(&mut args).present() {
             let flag = FlagSpec {
                 name: "foo",
                 min_index: cmd.index(),

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -93,6 +93,7 @@ impl Cmd {
     }
 
     /// Returns `Some(_)` if this subcommand is present.
+    #[deprecated(since = "0.3.0", note = "please use `present()` instead")]
     pub fn ok(self) -> Option<Self> {
         self.is_present().then_some(self)
     }
@@ -100,6 +101,11 @@ impl Cmd {
     /// Returns `true` if this subcommand is present.
     pub fn is_present(self) -> bool {
         matches!(self, Self::Some { .. })
+    }
+
+    /// Returns `Some(self)` if this subcommand is present.
+    pub fn present(self) -> Option<Self> {
+        self.is_present().then_some(self)
     }
 
     /// Returns the index at which the raw value associated with this subcommand was located in [`RawArgs`].

--- a/src/flag.rs
+++ b/src/flag.rs
@@ -173,6 +173,11 @@ impl Flag {
         !matches!(self, Flag::None { .. })
     }
 
+    /// Returns `Some(self)` if this flag is present.
+    pub fn present(self) -> Option<Self> {
+        self.is_present().then_some(self)
+    }
+
     /// Returns the index at which the raw value associated with this flag was located in [`RawArgs`].
     pub fn index(self) -> Option<usize> {
         match self {

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -346,6 +346,11 @@ impl Opt {
         !matches!(self, Opt::None { .. } | Opt::MissingValue { .. })
     }
 
+    /// Returns `Some(self)` if this option is present.
+    pub fn present(self) -> Option<Self> {
+        self.is_present().then_some(self)
+    }
+
     /// Returns the raw value of this option.
     #[deprecated(since = "0.3.0", note = "please use `present()` and `value()` instead")]
     pub fn raw_value(&self) -> Option<&str> {


### PR DESCRIPTION
# Copilot Summary 

This pull request introduces a new method `present()` for various argument types (`Arg`, `Cmd`, `Flag`, `Opt`) to streamline checking if an argument is present and returning it. Additionally, it deprecates some older methods in favor of this new approach.

New method `present()`:

* [`src/arg.rs`](diffhunk://#diff-a2f5019accd09bc830969d4890dc8eca8cdd9cfdfd27c350c4c317278b5c1a35R203-R207): Added `present()` method to `Arg` to return `Some(self)` if the argument is present.
* [`src/cmd.rs`](diffhunk://#diff-ce6e52385823f89d6bf1ea627c887cfd2a80b6fb8fc97932e5e3a9372d4ad7bbR106-R110): Added `present()` method to `Cmd` to return `Some(self)` if the subcommand is present.
* [`src/flag.rs`](diffhunk://#diff-cf56a442b181f245ec9700f63ad02e773b3399a050218b47d9fb4050fd0bedc2R176-R180): Added `present()` method to `Flag` to return `Some(self)` if the flag is present.
* [`src/opt.rs`](diffhunk://#diff-b91b0157c73f1643f94c1e8e2d0a24eb8f05d017d943005c8671f6244d58ad17R349-R353): Added `present()` method to `Opt` to return `Some(self)` if the option is present.

Deprecations:

* [`src/cmd.rs`](diffhunk://#diff-ce6e52385823f89d6bf1ea627c887cfd2a80b6fb8fc97932e5e3a9372d4ad7bbR96): Deprecated the `ok()` method in favor of the new `present()` method.

Test updates:

* [`src/cmd.rs`](diffhunk://#diff-ce6e52385823f89d6bf1ea627c887cfd2a80b6fb8fc97932e5e3a9372d4ad7bbL124-R132): Updated tests to use the new `present()` method instead of the deprecated `ok()` method.