### PR TITLE
Add `{Arg,Opt}::{then(),present_and_then()}()` and `present_and_then()` to `Arg` and `Opt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,12 @@ fn main() -> noargs::Result<()> {
     noargs::HELP_FLAG.take_help(&mut args);
 
     // Handle application specific args.
-    let foo: usize = noargs::opt("foo").default("1").take(&mut args).parse()?;
-    let bar: bool = noargs::flag("bar").take(&mut args).is_present();
-    let baz: Option<String> = noargs::arg("[BAZ]").take(&mut args).parse_if_present()?;
+    let foo: usize = noargs::opt("foo")
+        .default("1").take(&mut args).then(|o| o.value().parse())?;
+    let bar: bool = noargs::flag("bar")
+        .take(&mut args).is_present();
+    let baz: Option<String> = noargs::arg("[BAZ]")
+        .take(&mut args).present_and_then(|a| a.value().parse())?;
 
     // Check unexpected args and build help text if need.
     if let Some(help) = args.finish()? {

--- a/src/arg.rs
+++ b/src/arg.rs
@@ -211,8 +211,8 @@ impl Arg {
     /// let arg = noargs::arg("<NUMBER>").take(&mut args);
     ///
     /// // Parse as number and ensure it's positive
-    /// let num = arg.then(|a| -> Result<_, Box<dyn std::error::Error>> {
-    ///     let n: i32 = a.value().parse()?;
+    /// let num = arg.then(|arg| -> Result<_, Box<dyn std::error::Error>> {
+    ///     let n: i32 = arg.value().parse()?;
     ///     if n <= 0 {
     ///         return Err("number must be positive".into());
     ///     }

--- a/src/arg.rs
+++ b/src/arg.rs
@@ -338,9 +338,24 @@ mod tests {
     fn parse_arg() {
         let mut args = args(&["test", "1", "not a number"]);
         let arg = arg("ARG");
-        assert_eq!(arg.take(&mut args).parse::<usize>().ok(), Some(1));
-        assert_eq!(arg.take(&mut args).parse::<usize>().ok(), None);
-        assert_eq!(arg.take(&mut args).parse::<usize>().ok(), None);
+        assert_eq!(
+            arg.take(&mut args)
+                .then(|a| a.value().parse::<usize>())
+                .ok(),
+            Some(1)
+        );
+        assert_eq!(
+            arg.take(&mut args)
+                .then(|a| a.value().parse::<usize>())
+                .ok(),
+            None
+        );
+        assert_eq!(
+            arg.take(&mut args)
+                .then(|a| a.value().parse::<usize>())
+                .ok(),
+            None
+        );
     }
 
     fn args(raw_args: &[&str]) -> RawArgs {

--- a/src/arg.rs
+++ b/src/arg.rs
@@ -179,7 +179,7 @@ impl Arg {
         F: FnOnce(&Self) -> Result<T, E>,
         E: std::fmt::Display,
     {
-        f(self).map_err(|e| Error::ParseArgError {
+        f(self).map_err(|e| Error::InvalidArg {
             arg: Box::new(self.clone()),
             reason: e.to_string(),
         })
@@ -230,7 +230,7 @@ impl Arg {
     /// # Errors
     ///
     /// - Returns [`Error::MissingArg`] if `self.is_present()` is `false` (argument is missing)
-    /// - Returns [`Error::ParseArgError`] if `f(self)` returns `Err(_)` (validation or conversion failed)
+    /// - Returns [`Error::InvalidArg`] if `f(self)` returns `Err(_)` (validation or conversion failed)
     pub fn then<F, T, E>(self, f: F) -> Result<T, Error>
     where
         F: FnOnce(Self) -> Result<T, E>,
@@ -241,7 +241,7 @@ impl Arg {
                 arg: Box::new(self),
             });
         }
-        f(self.clone()).map_err(|e| Error::ParseArgError {
+        f(self.clone()).map_err(|e| Error::InvalidArg {
             arg: Box::new(self),
             reason: e.to_string(),
         })

--- a/src/arg.rs
+++ b/src/arg.rs
@@ -150,39 +150,33 @@ pub enum Arg {
 
 impl Arg {
     /// Parse the value of this argument.
+    #[deprecated(since = "0.3.0", note = "please use `then()` instead")]
     pub fn parse<T>(&self) -> Result<T, Error>
     where
         T: std::str::FromStr,
         T::Err: std::fmt::Display,
     {
-        let value = self
-            .is_present()
-            .then_some(self.value())
-            .ok_or_else(|| Error::MissingArg {
-                arg: Box::new(self.clone()),
-            })?;
-        self.parse_with(|_| value.parse())
+        self.clone().then(|arg| arg.value().parse())
     }
 
     /// Parse the value of this argument if it is present.
+    #[deprecated(since = "0.3.0", note = "please use `present_and_then()` instead")]
     pub fn parse_if_present<T>(&self) -> Result<Option<T>, Error>
     where
         T: std::str::FromStr,
         T::Err: std::fmt::Display,
     {
-        self.is_present().then(|| self.parse()).transpose()
+        self.clone().present_and_then(|arg| arg.value().parse())
     }
 
     /// Similar to [`Arg::parse()`], but more flexible as this method allows you to specify an arbitrary parsing function.
+    #[deprecated(since = "0.3.0", note = "please use `then()` instead")]
     pub fn parse_with<F, T, E>(&self, f: F) -> Result<T, Error>
     where
         F: FnOnce(&Self) -> Result<T, E>,
         E: std::fmt::Display,
     {
-        f(self).map_err(|e| Error::InvalidArg {
-            arg: Box::new(self.clone()),
-            reason: e.to_string(),
-        })
+        self.clone().then(|arg| f(&arg))
     }
 
     /// Returns the specification of this argument.
@@ -245,6 +239,15 @@ impl Arg {
             arg: Box::new(self),
             reason: e.to_string(),
         })
+    }
+
+    /// Shorthand for `self.present().map(|arg| arg.then(f)).transpose()`.
+    pub fn present_and_then<F, T, E>(self, f: F) -> Result<Option<T>, Error>
+    where
+        F: FnOnce(Self) -> Result<T, E>,
+        E: std::fmt::Display,
+    {
+        self.present().map(|arg| arg.then(f)).transpose()
     }
 
     /// Returns the raw value of this argument.

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,14 +22,14 @@ pub enum Error {
     MissingCommand {
         metadata: Metadata,
     },
-    ParseArgError {
+    InvalidArg {
         arg: Box<Arg>,
         reason: String,
     },
     MissingArg {
         arg: Box<Arg>,
     },
-    ParseOptError {
+    InvalidOpt {
         opt: Box<Opt>,
         reason: String,
     },
@@ -102,7 +102,7 @@ impl Error {
                 fmt.write("command is not specified");
                 *metadata
             }
-            Error::ParseArgError { arg, reason } => {
+            Error::InvalidArg { arg, reason } => {
                 fmt.write(&format!(
                     "argument '{}' has an invalid value {:?}: {reason}",
                     fmt.bold(arg.spec().name),
@@ -122,7 +122,7 @@ impl Error {
                     return fmt.finish();
                 }
             }
-            Error::ParseOptError { opt, reason } => {
+            Error::InvalidOpt { opt, reason } => {
                 let name = match &**opt {
                     Opt::Short {
                         spec: OptSpec { short: Some(c), .. },

--- a/src/error.rs
+++ b/src/error.rs
@@ -277,7 +277,7 @@ Try '--help' for more information."#
         args.metadata_mut().help_flag_name = None;
         let e = arg("INTEGER")
             .take(&mut args)
-            .parse::<usize>()
+            .then(|a| a.value().parse::<usize>())
             .expect_err("error");
         assert_eq!(
             e.to_string(false),
@@ -292,7 +292,7 @@ Try '--help' for more information."#
         let e = opt("foo")
             .short('f')
             .take(&mut args)
-            .parse::<usize>()
+            .then(|o| o.value().parse::<usize>())
             .expect_err("error");
         assert_eq!(
             e.to_string(false),
@@ -306,7 +306,7 @@ Try '--help' for more information."#
         args.metadata_mut().help_flag_name = None;
         let e = arg("INTEGER")
             .take(&mut args)
-            .parse::<usize>()
+            .then(|a| a.value().parse::<usize>())
             .expect_err("error");
         assert_eq!(e.to_string(false), "missing argument 'INTEGER'");
     }
@@ -318,7 +318,7 @@ Try '--help' for more information."#
         let e = opt("foo")
             .short('f')
             .take(&mut args)
-            .parse::<usize>()
+            .then(|o| o.value().parse::<usize>())
             .expect_err("error");
         assert_eq!(e.to_string(false), "missing '-f' value");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,9 +30,12 @@
 //!     noargs::HELP_FLAG.take_help(&mut args);
 //!
 //!     // Handle application specific args.
-//!     let foo: usize = noargs::opt("foo").default("1").take(&mut args).parse()?;
-//!     let bar: bool = noargs::flag("bar").take(&mut args).is_present();
-//!     let baz: Option<String> = noargs::arg("[BAZ]").take(&mut args).parse_if_present()?;
+//!     let foo: usize = noargs::opt("foo")
+//!         .default("1").take(&mut args).then(|o| o.value().parse())?;
+//!     let bar: bool = noargs::flag("bar")
+//!         .take(&mut args).is_present();
+//!     let baz: Option<String> = noargs::arg("[BAZ]")
+//!         .take(&mut args).present_and_then(|a| a.value().parse())?;
 //!
 //!     // Check unexpected args and build help text if need.
 //!     if let Some(help) = args.finish()? {

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -322,7 +322,7 @@ impl Opt {
         F: FnOnce(&Self) -> Result<T, E>,
         E: std::fmt::Display,
     {
-        f(self).map_err(|e| Error::ParseOptError {
+        f(self).map_err(|e| Error::InvalidOpt {
             opt: Box::new(self.clone()),
             reason: e.to_string(),
         })

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -293,39 +293,33 @@ pub enum Opt {
 
 impl Opt {
     /// Parse the value of this option.
+    #[deprecated(since = "0.3.0", note = "please use `then()` instead")]
     pub fn parse<T>(&self) -> Result<T, Error>
     where
         T: std::str::FromStr,
         T::Err: std::fmt::Display,
     {
-        let value = self
-            .is_present()
-            .then_some(self.value())
-            .ok_or_else(|| Error::MissingOpt {
-                opt: Box::new(self.clone()),
-            })?;
-        self.parse_with(|_| value.parse())
+        self.clone().then(|opt| opt.value().parse())
     }
 
     /// Parse the value of this option if it is present.
+    #[deprecated(since = "0.3.0", note = "please use `present_and_then()` instead")]
     pub fn parse_if_present<T>(&self) -> Result<Option<T>, Error>
     where
         T: std::str::FromStr,
         T::Err: std::fmt::Display,
     {
-        self.is_present().then(|| self.parse()).transpose()
+        self.clone().present_and_then(|opt| opt.value().parse())
     }
 
     /// Similar to [`Opt::parse()`], but more flexible as this method allows you to specify an arbitrary parsing function.
+    #[deprecated(since = "0.3.0", note = "please use `then()` instead")]
     pub fn parse_with<F, T, E>(&self, f: F) -> Result<T, Error>
     where
         F: FnOnce(&Self) -> Result<T, E>,
         E: std::fmt::Display,
     {
-        f(self).map_err(|e| Error::InvalidOpt {
-            opt: Box::new(self.clone()),
-            reason: e.to_string(),
-        })
+        self.clone().then(|opt| f(&opt))
     }
 
     /// Returns the specification of this option.
@@ -349,6 +343,57 @@ impl Opt {
     /// Returns `Some(self)` if this option is present.
     pub fn present(self) -> Option<Self> {
         self.is_present().then_some(self)
+    }
+
+    /// Applies additional conversion or validation to the option.
+    ///
+    /// This method allows for chaining transformations and validations when an option is present.
+    /// It first checks if the option has a value and then applies the provided function.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let mut args = noargs::RawArgs::new(["example", "--num=42"].iter().map(|a| a.to_string()));
+    /// let opt = noargs::opt("num").take(&mut args);
+    ///
+    /// // Parse as number and ensure it's positive
+    /// let num = opt.then(|opt| -> Result<_, Box<dyn std::error::Error>> {
+    ///     let n: i32 = opt.value().parse()?;
+    ///     if n <= 0 {
+    ///         return Err("number must be positive".into());
+    ///     }
+    ///     Ok(n)
+    /// })?;
+    /// # Ok::<(), noargs::Error>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// - Returns [`Error::MissingOpt`] if `self.is_present()` is `false` (option is missing)
+    /// - Returns [`Error::InvalidOpt`] if `f(self)` returns `Err(_)` (validation or conversion failed)
+    pub fn then<F, T, E>(self, f: F) -> Result<T, Error>
+    where
+        F: FnOnce(Self) -> Result<T, E>,
+        E: std::fmt::Display,
+    {
+        if !self.is_present() {
+            return Err(Error::MissingOpt {
+                opt: Box::new(self),
+            });
+        }
+        f(self.clone()).map_err(|e| Error::InvalidOpt {
+            opt: Box::new(self),
+            reason: e.to_string(),
+        })
+    }
+
+    /// Shorthand for `self.present().map(|opt| opt.then(f)).transpose()`.
+    pub fn present_and_then<F, T, E>(self, f: F) -> Result<Option<T>, Error>
+    where
+        F: FnOnce(Self) -> Result<T, E>,
+        E: std::fmt::Display,
+    {
+        self.present().map(|opt| opt.then(f)).transpose()
     }
 
     /// Returns the raw value of this option.

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -479,9 +479,24 @@ mod tests {
         let mut args = args(&["test", "--foo=1", "-f", "2", "--foo"]);
         let mut opt = opt("foo");
         opt.short = Some('f');
-        assert_eq!(opt.take(&mut args).parse::<usize>().ok(), Some(1));
-        assert_eq!(opt.take(&mut args).parse::<usize>().ok(), Some(2));
-        assert_eq!(opt.take(&mut args).parse::<usize>().ok(), None);
+        assert_eq!(
+            opt.take(&mut args)
+                .then(|o| o.value().parse::<usize>())
+                .ok(),
+            Some(1)
+        );
+        assert_eq!(
+            opt.take(&mut args)
+                .then(|o| o.value().parse::<usize>())
+                .ok(),
+            Some(2)
+        );
+        assert_eq!(
+            opt.take(&mut args)
+                .then(|o| o.value().parse::<usize>())
+                .ok(),
+            None
+        );
     }
 
     fn args(raw_args: &[&str]) -> RawArgs {


### PR DESCRIPTION
- **Add `then` method to Arg for chained validation and transformation of argument values**
- **Rename ParseArgError and ParseOptError to InvalidArg and InvalidOpt in error enums**
- **refactor: deprecate parse methods in favor of composable *then() methods**
- **Refactor option parsing API with new `then()` and `present_and_then()` methods**
- **Refactor parsing functions to use `then` and `present_and_then` for more idiomatic error handling**
