### PR TITLE
Fix short option value handling

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -287,7 +287,7 @@ Try '--help' for more information."#
 
     #[test]
     fn parse_opt_error() {
-        let mut args = RawArgs::new(["noargs", "-f=bar"].iter().map(|a| a.to_string()));
+        let mut args = RawArgs::new(["noargs", "-fbar"].iter().map(|a| a.to_string()));
         args.metadata_mut().help_flag_name = None;
         let e = opt("foo")
             .short('f')

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -190,28 +190,24 @@ impl OptSpec {
                 }
 
                 // Short name option.
-                match value[1..].chars().nth(1) {
-                    None => {
-                        raw_arg.value = None;
-                        pending = Some(Opt::Short {
-                            spec: self,
-                            metadata,
-                            index,
-                            value: "".to_owned(),
-                        });
-                    }
-                    Some('=') => {
-                        let opt_name_len = self.short.map(|c| c.len_utf8()).unwrap_or(0);
-                        let opt_value = value[1 + opt_name_len + 1..].to_owned();
-                        raw_arg.value = None;
-                        return Opt::Short {
-                            spec: self,
-                            metadata,
-                            index,
-                            value: opt_value,
-                        };
-                    }
-                    Some(_) => {}
+                let opt_name_len = self.short.map(|c| c.len_utf8()).unwrap_or(0);
+                let value = value[1 + opt_name_len..].to_owned();
+                if value.is_empty() {
+                    raw_arg.value = None;
+                    pending = Some(Opt::Short {
+                        spec: self,
+                        metadata,
+                        index,
+                        value: "".to_owned(),
+                    });
+                } else {
+                    raw_arg.value = None;
+                    return Opt::Short {
+                        spec: self,
+                        metadata,
+                        index,
+                        value,
+                    };
                 }
             }
 
@@ -445,7 +441,7 @@ mod tests {
 
     #[test]
     fn required_opt() {
-        let mut args = args(&["test", "--foo", "bar", "-f=baz"]);
+        let mut args = args(&["test", "--foo", "bar", "-fbaz"]);
         let mut opt = opt("foo");
         opt.short = Some('f');
         assert!(matches!(opt.take(&mut args), Opt::Long { index: 1, .. }));

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -185,13 +185,13 @@ impl OptSpec {
                         Some(_) => {}
                     }
                     continue;
-                } else if value[1..].chars().next() != self.short {
-                    continue;
                 }
 
                 // Short name option.
-                let opt_name_len = self.short.map(|c| c.len_utf8()).unwrap_or(0);
-                let value = value[1 + opt_name_len..].to_owned();
+                let Some(value) = self.short.and_then(|c| value[1..].strip_prefix(c)) else {
+                    continue;
+                };
+                let value = value.to_owned();
                 if value.is_empty() {
                     raw_arg.value = None;
                     pending = Some(Opt::Short {


### PR DESCRIPTION
# Copilot Summary

This pull request includes changes to improve the handling of short name options and their parsing in the `src/opt.rs` and `src/error.rs` files. The most important changes include modifying the way short name options are parsed and updating related test cases.

Improvements to short name options parsing:

* [`src/opt.rs`](diffhunk://#diff-b91b0157c73f1643f94c1e8e2d0a24eb8f05d017d943005c8671f6244d58ad17L193-L215): Modified the `OptSpec` implementation to handle short name options without the equal sign and to correctly parse their values.

Updates to test cases:

* [`src/opt.rs`](diffhunk://#diff-b91b0157c73f1643f94c1e8e2d0a24eb8f05d017d943005c8671f6244d58ad17L448-R444): Updated the `required_opt` test to reflect the new short name option parsing behavior by changing `-f=baz` to `-fbaz`.
* [`src/error.rs`](diffhunk://#diff-97e25e2a0e41c578875856e97b659be2719a65227c104b992e3144efa000c35eL290-R290): Updated the `parse_opt_error` test to reflect the new short name option parsing behavior by changing `-f=bar` to `-fbar`.