### PR TITLE
Add comprehensive examples and enable example checking in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       - run: rustup update ${{ matrix.toolchain }}
       - run: rustup default ${{ matrix.toolchain }}
       - run: cargo check --all
+      - run: cargo check --examples
 
   test:
     name: Test Suite

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ fn main() -> noargs::Result<()> {
 
 For a fuller no-subcommand example (with common pitfalls), see
 [`examples/basics.rs`](examples/basics.rs).
+For repeated options / positional arrays, see
+[`examples/arrays.rs`](examples/arrays.rs).
 
 ### Subcommands
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ fn main() -> noargs::Result<()> {
 
 ### Subcommands
 
-The following example shows how to handle subcommands:
+The following example shows how to handle subcommands.
+For a fuller command-routing pattern, see
+[`examples/subcommands.rs`](examples/subcommands.rs).
 
 ```rust
 fn main() -> noargs::Result<()> {
@@ -96,7 +98,6 @@ fn main() -> noargs::Result<()> {
             .default("8080")
             .take(&mut args)
             .then(|o| o.value().parse())?;
-
         println!("Starting service on port {}", port);
     } else if noargs::cmd("stop")
         .doc("Stop the service")
@@ -106,10 +107,8 @@ fn main() -> noargs::Result<()> {
         println!("Stopping service");
     } else if let Some(help) = args.finish()? {
         print!("{help}");
-        return Ok(());
     }
 
     Ok(())
 }
 ```
-

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ fn main() -> noargs::Result<()> {
 }
 ```
 
+For a fuller no-subcommand example (with common pitfalls), see
+[`examples/basics.rs`](examples/basics.rs).
+
 ### Subcommands
 
 The following example shows how to handle subcommands.

--- a/examples/arrays.rs
+++ b/examples/arrays.rs
@@ -1,0 +1,71 @@
+fn main() -> noargs::Result<()> {
+    let mut args = noargs::raw_args();
+    args.metadata_mut().app_name = env!("CARGO_PKG_NAME");
+    args.metadata_mut().app_description = env!("CARGO_PKG_DESCRIPTION");
+
+    if noargs::VERSION_FLAG.take(&mut args).is_present() {
+        println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
+    noargs::HELP_FLAG.take_help(&mut args);
+
+    // Same-name options can be collected by calling take() in a loop.
+    let include_opt = noargs::opt("include")
+        .short('I')
+        .ty("PATH")
+        .doc("Include path (can be specified multiple times)");
+    let mut includes = Vec::<String>::new();
+    while let Some(path) = include_opt
+        .take(&mut args)
+        .present_and_then(|o| o.value().parse())?
+    {
+        includes.push(path);
+    }
+
+    let label_opt = noargs::opt("label")
+        .short('l')
+        .ty("LABEL")
+        .doc("Label value (can be specified multiple times)");
+    let mut labels = Vec::<String>::new();
+    while let Some(label) = label_opt
+        .take(&mut args)
+        .present_and_then(|o| o.value().parse())?
+    {
+        labels.push(label);
+    }
+
+    let output: String = noargs::opt("output")
+        .short('o')
+        .ty("PATH")
+        .doc("Output path")
+        .default("summary.txt")
+        .take(&mut args)
+        .then(|o| o.value().parse())?;
+
+    // Positional arrays are handled with one required argument + optional rest.
+    // Naming convention: use `<NAME>...` for required-many and `[NAME]...` for optional-many.
+    let first_input: String = noargs::arg("<INPUT>")
+        .doc("First input (required)")
+        .example("a.txt")
+        .take(&mut args)
+        .then(|a| a.value().parse())?;
+    let rest_input_arg = noargs::arg("[INPUT]...").doc("Additional inputs");
+    let mut inputs = vec![first_input];
+    while let Some(input) = rest_input_arg
+        .take(&mut args)
+        .present_and_then(|a| a.value().parse())?
+    {
+        inputs.push(input);
+    }
+
+    if let Some(help) = args.finish()? {
+        print!("{help}");
+        return Ok(());
+    }
+
+    println!("includes={includes:?}");
+    println!("labels={labels:?}");
+    println!("inputs={inputs:?}");
+    println!("output={output}");
+    Ok(())
+}

--- a/examples/basics.rs
+++ b/examples/basics.rs
@@ -17,7 +17,7 @@ fn main() -> noargs::Result<()> {
         .take(&mut args)
         .is_present();
     let dry_run = noargs::flag("dry-run")
-        .doc("Print parsed values without doing work")
+        .doc("Print parsed values and exit without running processing")
         .take(&mut args)
         .is_present();
     let retries: usize = noargs::opt("retries")
@@ -70,10 +70,13 @@ fn main() -> noargs::Result<()> {
         println!(
             "dry-run: verbose={verbose}, retries={retries}, endpoint={endpoint}, format={format}, timeout_secs={timeout_secs:?}, input={input}, output={output}"
         );
-    } else {
-        println!(
-            "verbose={verbose}, retries={retries}, endpoint={endpoint}, format={format}, timeout_secs={timeout_secs:?}, input={input}, output={output}"
-        );
+        return Ok(());
+    }
+
+    println!("processing: {input} -> {output}");
+    println!("using endpoint={endpoint}, format={format}, retries={retries}");
+    if verbose {
+        println!("verbose: timeout_secs={timeout_secs:?}");
     }
 
     Ok(())

--- a/examples/basics.rs
+++ b/examples/basics.rs
@@ -66,6 +66,8 @@ fn main() -> noargs::Result<()> {
         .then(|a| a.value().parse())?;
 
     if let Some(help) = args.finish()? {
+        // When help is requested, finish() returns the built help text.
+        // Print it here and exit without running application logic.
         print!("{help}");
         return Ok(());
     }

--- a/examples/basics.rs
+++ b/examples/basics.rs
@@ -1,0 +1,80 @@
+fn main() -> noargs::Result<()> {
+    let mut args = noargs::raw_args();
+    args.metadata_mut().app_name = env!("CARGO_PKG_NAME");
+    args.metadata_mut().app_description = env!("CARGO_PKG_DESCRIPTION");
+
+    if noargs::VERSION_FLAG.take(&mut args).is_present() {
+        println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
+    noargs::HELP_FLAG.take_help(&mut args);
+
+    // Important: call flag()/opt() before arg().
+    // Otherwise values like "-v" can be consumed as positional arguments.
+    let verbose = noargs::flag("verbose")
+        .short('v')
+        .doc("Enable verbose output")
+        .take(&mut args)
+        .is_present();
+    let dry_run = noargs::flag("dry-run")
+        .doc("Print parsed values without doing work")
+        .take(&mut args)
+        .is_present();
+    let retries: usize = noargs::opt("retries")
+        .short('r')
+        .ty("N")
+        .doc("How many times to retry")
+        .default("1")
+        .take(&mut args)
+        .then(|o| o.value().parse())?;
+    let endpoint: String = noargs::opt("endpoint")
+        .ty("URL")
+        .doc("Server endpoint")
+        .env("NOARGS_ENDPOINT")
+        .default("http://localhost:8080")
+        .take(&mut args)
+        .then(|o| o.value().parse())?;
+    // Important: a required option should set example()
+    // so help mode can still produce meaningful usage/example text.
+    let format: String = noargs::opt("format")
+        .ty("FORMAT")
+        .doc("Output format")
+        .example("json")
+        .take(&mut args)
+        .then(|o| o.value().parse())?;
+    let timeout_secs: Option<u64> = noargs::opt("timeout")
+        .ty("SECONDS")
+        .doc("Optional timeout in seconds")
+        .take(&mut args)
+        .present_and_then(|o| o.value().parse())?;
+
+    // Important: a required positional argument should set example()
+    // so help mode can still produce meaningful usage/example text.
+    let input: String = noargs::arg("<INPUT>")
+        .doc("Input file path")
+        .example("input.txt")
+        .take(&mut args)
+        .then(|a| a.value().parse())?;
+    let output: String = noargs::arg("[OUTPUT]")
+        .doc("Output file path")
+        .default("out.txt")
+        .take(&mut args)
+        .then(|a| a.value().parse())?;
+
+    if let Some(help) = args.finish()? {
+        print!("{help}");
+        return Ok(());
+    }
+
+    if dry_run {
+        println!(
+            "dry-run: verbose={verbose}, retries={retries}, endpoint={endpoint}, format={format}, timeout_secs={timeout_secs:?}, input={input}, output={output}"
+        );
+    } else {
+        println!(
+            "verbose={verbose}, retries={retries}, endpoint={endpoint}, format={format}, timeout_secs={timeout_secs:?}, input={input}, output={output}"
+        );
+    }
+
+    Ok(())
+}

--- a/examples/basics.rs
+++ b/examples/basics.rs
@@ -36,6 +36,8 @@ fn main() -> noargs::Result<()> {
         .then(|o| o.value().parse())?;
     // Important: a required option should set example()
     // so help mode can still produce meaningful usage/example text.
+    // Optional options are fine without example() when you use
+    // default() or present_and_then().
     let format: String = noargs::opt("format")
         .ty("FORMAT")
         .doc("Output format")
@@ -50,6 +52,8 @@ fn main() -> noargs::Result<()> {
 
     // Important: a required positional argument should set example()
     // so help mode can still produce meaningful usage/example text.
+    // Optional positional arguments are fine without example() when you use
+    // default() or present_and_then().
     let input: String = noargs::arg("<INPUT>")
         .doc("Input file path")
         .example("input.txt")

--- a/examples/subcommands.rs
+++ b/examples/subcommands.rs
@@ -1,0 +1,123 @@
+fn main() -> noargs::Result<()> {
+    let mut args = noargs::raw_args();
+    args.metadata_mut().app_name = env!("CARGO_PKG_NAME");
+    args.metadata_mut().app_description = env!("CARGO_PKG_DESCRIPTION");
+
+    if noargs::VERSION_FLAG.take(&mut args).is_present() {
+        println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
+    noargs::HELP_FLAG.take_help(&mut args);
+
+    // In real applications, split each `try_run_*` command into separate modules/files.
+    let _ = try_run_hello(&mut args)? || try_run_sum(&mut args)? || try_run_echo(&mut args)?;
+
+    if let Some(help) = args.finish()? {
+        print!("{help}");
+    }
+
+    Ok(())
+}
+
+fn try_run_hello(args: &mut noargs::RawArgs) -> noargs::Result<bool> {
+    if !noargs::cmd("hello")
+        .doc("Print a greeting")
+        .take(args)
+        .is_present()
+    {
+        return Ok(false);
+    }
+
+    let loud = noargs::flag("loud")
+        .short('l')
+        .doc("Print greeting in upper case")
+        .take(args)
+        .is_present();
+    let name: String = noargs::arg("<NAME>")
+        .doc("Name to greet")
+        .example("Alice")
+        .take(args)
+        .then(|a| a.value().parse())?;
+
+    if args.metadata().help_mode {
+        return Ok(true);
+    }
+
+    let message = format!("Hello, {name}!");
+    if loud {
+        println!("{}", message.to_uppercase());
+    } else {
+        println!("{message}");
+    }
+    Ok(true)
+}
+
+fn try_run_sum(args: &mut noargs::RawArgs) -> noargs::Result<bool> {
+    if !noargs::cmd("sum")
+        .doc("Add two integers")
+        .take(args)
+        .is_present()
+    {
+        return Ok(false);
+    }
+
+    let repeat: usize = noargs::opt("repeat")
+        .short('r')
+        .ty("N")
+        .doc("Print result multiple times")
+        .default("1")
+        .take(args)
+        .then(|o| o.value().parse())?;
+    let left: i64 = noargs::arg("<LEFT>")
+        .doc("Left operand")
+        .example("3")
+        .take(args)
+        .then(|a| a.value().parse())?;
+    let right: i64 = noargs::arg("<RIGHT>")
+        .doc("Right operand")
+        .example("4")
+        .take(args)
+        .then(|a| a.value().parse())?;
+
+    if args.metadata().help_mode {
+        return Ok(true);
+    }
+
+    let total = left + right;
+    for _ in 0..repeat {
+        println!("{total}");
+    }
+    Ok(true)
+}
+
+fn try_run_echo(args: &mut noargs::RawArgs) -> noargs::Result<bool> {
+    if !noargs::cmd("echo")
+        .doc("Print a message")
+        .take(args)
+        .is_present()
+    {
+        return Ok(false);
+    }
+
+    let upper = noargs::flag("upper")
+        .short('u')
+        .doc("Uppercase the message")
+        .take(args)
+        .is_present();
+    let text: String = noargs::arg("<TEXT>")
+        .doc("Message text")
+        .example("hello world")
+        .take(args)
+        .then(|a| a.value().parse())?;
+
+    if args.metadata().help_mode {
+        return Ok(true);
+    }
+
+    if upper {
+        println!("{}", text.to_uppercase());
+    } else {
+        println!("{text}");
+    }
+    Ok(true)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,8 @@
 //! }
 //! ```
 //!
+//! For a fuller no-subcommand example (with common pitfalls), see `examples/basics.rs`.
+//!
 //! The following example shows how to handle subcommands.
 //! For a fuller command-routing pattern, see `examples/subcommands.rs`.
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@
 //! ```
 //!
 //! For a fuller no-subcommand example (with common pitfalls), see `examples/basics.rs`.
+//! For repeated options / positional arrays, see `examples/arrays.rs`.
 //!
 //! The following example shows how to handle subcommands.
 //! For a fuller command-routing pattern, see `examples/subcommands.rs`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,8 @@
 //! }
 //! ```
 //!
-//! The following example shows how to handle subcommands:
+//! The following example shows how to handle subcommands.
+//! For a fuller command-routing pattern, see `examples/subcommands.rs`.
 //! ```
 //! fn main() -> noargs::Result<()> {
 //!     let mut args = noargs::raw_args();
@@ -85,7 +86,6 @@
 //!         println!("Stopping service");
 //!     } else if let Some(help) = args.finish()? {
 //!         print!("{help}");
-//!         return Ok(());
 //!     }
 //!
 //!     Ok(())


### PR DESCRIPTION
## Summary

This PR expands and hardens the example story for `noargs` so users can learn real usage patterns from runnable code.

## What changed

1. Added/expanded runnable examples:
- `examples/subcommands.rs`
  - Command routing pattern using `try_run_*` handlers (`hello`, `sum`, `echo`)
  - Demonstrates subcommand docs/help behavior
- `examples/basics.rs`
  - Full non-subcommand flow with `flag`, `opt`, `arg`, defaults, env, and help handling
  - Explicit anti-footgun comments:
    - Parse `flag/opt` before positional `arg`
    - Required `arg/opt` should use `example()` for help-mode UX
    - Optional values can rely on `default()` or `present_and_then()`
  - Includes `opt().env()` usage (`--endpoint` / `NOARGS_ENDPOINT`)
  - Clarifies `finish()` help printing path and makes `--dry-run` behavior distinct
- `examples/arrays.rs`
  - Demonstrates repeated same-name options and positional arrays
  - Uses looped `take(...).present_and_then(...)` collection patterns
  - Adds naming-convention note for `<NAME>...` and `[NAME]...`

2. CI improvement:
- Added `cargo check --examples` to `.github/workflows/ci.yml` (`check` job)

3. Documentation updates:
- Updated `README.md` and `src/lib.rs` docs to point to:
  - `examples/basics.rs`
  - `examples/arrays.rs`
  - `examples/subcommands.rs`

## Why

The goal is to reduce onboarding friction with practical, copy-pasteable examples while ensuring they stay buildable over time.

## Validation

- `cargo fmt --all`
- `cargo test --all`
- `cargo check --examples`
- Manual example runs:
  - `cargo run --example basics -- --help`
  - `cargo run --example basics -- --dry-run --format json input.txt`
  - `cargo run --example arrays -- --help`
  - `cargo run --example arrays -- -I inc1 -I inc2 -l fast -l nightly a.txt b.txt c.txt -o result.txt`
  - `cargo run --example subcommands -- --help`
